### PR TITLE
add missing subtype to Salvaged Vanadis Armory

### DIFF
--- a/pack/cd.json
+++ b/pack/cd.json
@@ -40,6 +40,7 @@
         "faction_cost": 3,
         "flavor": "Vanadis, a Martian arms manufacturer, was among the first sites targeted from orbit during the war.",
         "illustrator": "Michał Miłkowski",
+        "keywords": "Clan",
         "pack_code": "cd",
         "position": 103,
         "quantity": 3,


### PR DESCRIPTION
Missing "Clan" 