### PR TITLE
add missing translation for Ultraviolet Clearance

### DIFF
--- a/translations/de/pack/td.de.json
+++ b/translations/de/pack/td.de.json
@@ -242,14 +242,16 @@
     },
     {
         "code": "13038",
-        "text": "",
-        "title": ""
+        "flavor": "\"Falls es verborgene Partitionen in diesem System gäbe, würde ich das wissen, ich leite diese Abteilung.\"",
+        "keywords": "Transaktion - Verdreifachen",
+        "text": "Als zusätzliche Ausspielkosten für diese Operation zahle [click][click].\nErhalte 10[credit] und ziehe 4 Karten. Installiere 1 Karte (und zahle die Kosten dafür).",
+        "title": "Sicherheitsfreigabe Ultraviolett"
     },
     {
         "code": "13039",
-        "flavor": "Allein das Wissen um die Existenz dieses Stockers reicht aus, um ausgeknipst zu werden.",
+        "flavor": "Allein das Wissen um die Existenz dieses Stocks reicht aus, um ausgeknipst zu werden.",
         "keywords": "Sicherheitsprotokoll",
-        "text": "Immer wenn ein Run auf dieses System erfolgreich ist, erhält der Runner entweder 1 Kirn-schaden oder stöpselt sich aus. Falls der Runner sich ausstöpselt, erhälst du 5[credit], ziehst 1 Karte und zerstörst Sicherheitsfreigabe Schwarz.",
+        "text": "Immer wenn ein Run auf dieses System erfolgreich ist, erhält der Runner entweder 1 Hirn-Schaden oder stöpselt sich aus. Falls der Runner sich ausstöpselt, erhälst du 5[credit], ziehst 1 Karte und zerstörst Sicherheitsfreigabe Schwarz.",
         "title": "Sicherheitsfreigabe Schwarz"
     },
     {


### PR DESCRIPTION
fix typos in Black Level Clearance

@Alsciende it'd be great if you could merge this into production soon, the current empty translation record for UVC creates problem for Net Deck (which I'll fix of course, but that will take some time)