### PR TITLE
Updating cycles for Oct 2017 rotation

### DIFF
--- a/cycles.json
+++ b/cycles.json
@@ -10,14 +10,14 @@
         "code": "core",
         "name": "Core Set",
         "position": 1,
-        "rotated": false,
+        "rotated": true,
         "size": 1
     },
     {
         "code": "genesis",
         "name": "Genesis",
         "position": 2,
-        "rotated": false,
+        "rotated": true,
         "size": 6
     },
     {
@@ -31,7 +31,7 @@
         "code": "spin",
         "name": "Spin",
         "position": 4,
-        "rotated": false,
+        "rotated": true,
         "size": 6
     },
     {


### PR DESCRIPTION
Marked `Core`, `Spin`, and `Genesis` as rotated in `cycles.json`

Also saw that there was a `rotations.json` file, should I be using that instead of the `rotated` flag? If so, let's remove the `rotated` field.