### PR TITLE
typos in kitara cards; removed astro errata

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -1463,7 +1463,7 @@
         "position": 81,
         "quantity": 2,
         "side_code": "corp",
-        "text": "Place 1 agenda counter on AstroScript Pilot Program when you score it.\n<strong>Hosted agenda counter:</strong> Place 1 advancement token on a card that can be advanced.\nLimit 1 per deck.\n<errata>Errata from FAQ 3.1</errata>",
+        "text": "Place 1 agenda counter on AstroScript Pilot Program when you score it.\n<strong>Hosted agenda counter:</strong> Place 1 advancement token on a card that can be advanced.",
         "title": "AstroScript Pilot Program",
         "type_code": "agenda",
         "uniqueness": false

--- a/pack/core.json
+++ b/pack/core.json
@@ -1455,7 +1455,7 @@
         "advancement_cost": 3,
         "agenda_points": 2,
         "code": "01081",
-        "deck_limit": 1,
+        "deck_limit": 3,
         "faction_code": "nbn",
         "illustrator": "Matt Zeilinger",
         "keywords": "Initiative",

--- a/pack/ka.json
+++ b/pack/ka.json
@@ -47,7 +47,7 @@
         "position": 103,
         "quantity": 3,
         "side_code": "runner",
-        "text": "The first time you break all subroutines on the outermost piece of ice during a run each turn, you may remove hippo from the game to trash that piece of ice.",
+        "text": "The first time you break all subroutines on the outermost piece of ice during a run each turn, you may remove Hippo from the game to trash that piece of ice.",
         "title": "Hippo",
         "type_code": "hardware",
         "uniqueness": true
@@ -314,7 +314,7 @@
         "quantity": 3,
         "side_code": "corp",
         "strength": null,
-        "text": "X is twice the number of ice protecting this server.\n[subroutine]<trace>Trace X</trace> If successful, give the Runner 2 tags.n\n[subroutine]<trace>Trace X</trace> If successfu, end the run.",
+        "text": "X is twice the number of ice protecting this server.\n[subroutine]<trace>Trace X</trace> If successful, give the Runner 2 tags.\n[subroutine]<trace>Trace X</trace> If successful, end the run.",
         "title": "Surveyor",
         "type_code": "ice",
         "uniqueness": false

--- a/pack/tdatd.json
+++ b/pack/tdatd.json
@@ -82,7 +82,7 @@
         "quantity": 3,
         "side_code": "corp",
         "strength": 5,
-        "text": "When the Runner encounters Oduduwa, place 1 advancement token on it. You may play X adavancement tokens on another piece of ice. X is the number of advancement tokens on Oduduwa.\n[subroutine] End the run\n[subroutine] End the run",
+        "text": "When the Runner encounters Oduduwa, place 1 advancement token on it. You may place X adavancement tokens on another piece of ice. X is the number of advancement tokens on Oduduwa.\n[subroutine] End the run\n[subroutine] End the run",
         "title": "Oduduwa",
         "type_code": "ice",
         "uniqueness": true


### PR DESCRIPTION
Fixed up some typos for spoiled Kitara cards for clarity/accuracy.

In addition, I removed the errata from AstroScript.  As per the most recent FAQ, Astro no longer has errata due to rotation, so the "Limit 1 per deck" is not in force.