### PR TITLE
Fix typos in Forced Connection

### DIFF
--- a/pack/dtwn.json
+++ b/pack/dtwn.json
@@ -299,7 +299,7 @@
         "position": 37,
         "quantity": 3,
         "side_code": "corp",
-        "text": "If Forced Connection is accessed from R&D, the Runner must reveal it.\nWhen the Runner accesses Forced Connection <trace>Trace 3</trace> If successful, give the Runner 2 tags. Ignore this ability if the Runner accesses Forced Connection from Archives.",
+        "text": "If Forced Connection is accessed from R&D, the Runner must reveal it.\nWhen the Runner accesses Forced Connection, <trace>trace 3</trace> If successful, give the Runner 2 tags. Ignore this ability if the Runner accesses Forced Connection from Archives.",
         "title": "Forced Connection",
         "trash_cost": 0,
         "type_code": "upgrade",


### PR DESCRIPTION
Fixed a missing comma and incorrectly capitalized t in Trace 3 for Forced Connection.