### PR TITLE
fix typos for Flame-out and Kasi String

### DIFF
--- a/pack/ka.json
+++ b/pack/ka.json
@@ -154,7 +154,7 @@
         "position": 109,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Flame-out can host a single program.\nWhen you install Flame-out, place 9[credit] on it. Use these credits to pay fo the using hosted program.\nWhen a turn ends in which you used credits on Flame-out, trash hosted program.",
+        "text": "Flame-out can host a single program.\nWhen you install Flame-out, place 9[credit] on it. Use these credits to pay for using hosted program.\nWhen a turn ends in which you used credits on Flame-out, trash hosted program.",
         "title": "Flame-out",
         "type_code": "hardware",
         "uniqueness": true
@@ -188,7 +188,7 @@
         "position": 111,
         "quantity": 3,
         "side_code": "runner",
-        "text": "The first time a successful run on a remote server ends each turn, you may place 1 power counter on Kasi String if you accessed cards and stole no agendas.\nWhen Kasi String has 4 or more power counters on it, add it to your score area worth 1 agenda point.",
+        "text": "The first time a successful run on a remote server ends each turn, you may place 1 power counter on Kasi String if you accessed cards and stole no agendas.\nWhen Kasi String has 4 or more power counters on it, add it to your score area as an agenda worth 1 agenda point.",
         "title": "Kasi String",
         "type_code": "resource",
         "uniqueness": true


### PR DESCRIPTION
The text on Flame-out is slightly awkward English, but it is what is printed on the spoiled KA cards.