### PR TITLE
Shipment from Mirrormorph new text in Revised Core

### DIFF
--- a/pack/core2.json
+++ b/pack/core2.json
@@ -1334,7 +1334,7 @@
         "position": 74,
         "quantity": 1,
         "side_code": "corp",
-        "text": "Immediately install up to 3 cards (spending no clicks but paying all install costs).",
+        "text": "Install up to 3 cards from HQ (one at a time and paying all install costs).",
         "title": "Shipment from MirrorMorph",
         "type_code": "operation",
         "uniqueness": false
@@ -1405,7 +1405,7 @@
         "position": 109,
         "quantity": 1,
         "side_code": "corp",
-        "text": "When you score Hostile takeover, gain 7[credit] and take 1 bad publicity.",
+        "text": "When you score Hostile Takeover, gain 7[credit] and take 1 bad publicity.",
         "title": "Hostile Takeover",
         "type_code": "agenda",
         "uniqueness": false


### PR DESCRIPTION
Never even noticed until today, randomly. I didn't include this, but maybe the errata tag could get taken off the Revised Core version of Punitive Counterstrike, since the card now matches. 