### PR TITLE
Fixed influence cost of NEXT Diamond

### DIFF
--- a/pack/ka.json
+++ b/pack/ka.json
@@ -198,7 +198,7 @@
         "cost": 10,
         "deck_limit": 3,
         "faction_code": "haas-bioroid",
-        "faction_cost": 5,
+        "faction_cost": 4,
         "flavor": "Defenses that last forever.",
         "illustrator": "Ed Mattinian",
         "keywords": "Sentry - NEXT - Destroyer - AP",


### PR DESCRIPTION
Image and cardgamedb says that NEXT Diamond costs 4 influence, data previously had it at 5.