### PR TITLE
Fixed card quantity for SC19.

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -375,7 +375,7 @@
         "ffg_id": null,
         "name": "System Core 2019",
         "position": 1,
-        "size": 148
+        "size": 147
     },
     {
         "code": "si",


### PR DESCRIPTION
Quantity for SC19 was 148, but should be 147, which was causing the "Browse by set" list for example to show it as "147/148" despite all cards being included.