### PR TITLE
Added Astro errata

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -1463,10 +1463,10 @@
         "position": 81,
         "quantity": 2,
         "side_code": "corp",
-        "text": "Place 1 agenda counter on AstroScript Pilot Program when you score it.\n<strong>Hosted agenda counter:</strong> Place 1 advancement token on a card that can be advanced.",
+        "text": "Place 1 agenda counter on AstroScript Pilot Program when you score it.\n<strong>Hosted agenda counter:</strong> Place 1 advancement token on a card that can be advanced.\nLimit 1 per deck.\n<errata>Errata from FAQ 3.1</errata>",
         "title": "AstroScript Pilot Program",
         "type_code": "agenda",
-        "uniqueness": false
+        "uniqueness": true
     },
     {
         "advancement_cost": 2,


### PR DESCRIPTION
Added errata from FAQ 3.1 to Astroscript Pilot Program (Limit 1 per deck). With Eternal format out there now, it's probably worth fixing this.

In the process, I seem to have broken my local dev environment, so cannot fully test that this works as expected - I can see that the errata show on the card page as expected, but I didn't get a chance to test whether the cards is now limited to a quantity of 1 on the Build tab of deckbuilder, so if someone could give this a pull and check before merging it, that would be great!

Pending successful tests, I believe this resolves [this issue](https://github.com/Alsciende/netrunnerdb/issues/29) from the netrunnerdb repo.