### PR TITLE
Non-icebreakers can't have null strength

### DIFF
--- a/pack/cotc.json
+++ b/pack/cotc.json
@@ -13,7 +13,6 @@
         "position": 41,
         "quantity": 3,
         "side_code": "runner",
-        "strength": null,
         "text": "Whenever you access cards from R&D, access 1 additional card.\nTrash eXer if the Corp purges virus counters.",
         "title": "eXer",
         "type_code": "program",

--- a/pack/win.json
+++ b/pack/win.json
@@ -31,7 +31,6 @@
         "position": 82,
         "quantity": 3,
         "side_code": "runner",
-        "strength": null,
         "text": "Install Trypano only on a piece of ice.\nWhen Trypano has 5 or more virus counters on it, trash host ice.\nWhen your turn begins, you may place 1 virus counter on Trypano.",
         "title": "Trypano",
         "type_code": "program",


### PR DESCRIPTION
Removes `null` strength from Trypano and eXer.