### PR TITLE
CR 1.2 Errata

### DIFF
--- a/pack/baw.json
+++ b/pack/baw.json
@@ -64,7 +64,7 @@
         "position": 64,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Place X power counters on Bug Out Bag when you install it. If you have no cards in your grip at the end of your turn, draw 1 card for each counter on Bug Out Bag, then trash it.",
+        "text": "Place X power counters on Bug Out Bag when you install it. If you have no cards in your grip at the end of your turn, draw 1 card for each power counter on Bug Out Bag, then trash it.\n<errata>Errata from CR 1.2</errata>",
         "title": "Bug Out Bag",
         "type_code": "resource",
         "uniqueness": false

--- a/pack/core.json
+++ b/pack/core.json
@@ -48,7 +48,7 @@
         "position": 3,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Make a run on HQ or R&D. You may trash, at no cost, any cards you access (even if the cards cannot normally be trashed).",
+        "text": "Run HQ or R&D. During that run, you may pay 0[credit] to trash any card you are accessing (even if it has no trash cost).\n<errata>Errata from CR 1.2</errata>",
         "title": "Demolition Run",
         "type_code": "event",
         "uniqueness": false
@@ -1353,7 +1353,7 @@
         "quantity": 2,
         "side_code": "corp",
         "strength": 4,
-        "text": "[subroutine] The next piece of ice the Runner encounters during this run has +2 strength. Do 3 net damage unless the Runner breaks all subroutines on that piece of ice.",
+        "text": "[subroutine] The next piece of ice the Runner encounters during this run has +2 strength. When that encounter ends, if the Runner did not break all subroutines on that ice, do 3 net damage.\n<errata>Errata from CR 1.2</errata>",
         "title": "Chum",
         "type_code": "ice",
         "uniqueness": false

--- a/pack/core2.json
+++ b/pack/core2.json
@@ -31,7 +31,7 @@
         "position": 2,
         "quantity": 2,
         "side_code": "runner",
-        "text": "Make a run on HQ or R&D. You may trash, at no cost, any cards you access (even if the cards cannot normally be trashed).",
+        "text": "Run HQ or R&D. During that run, you may pay 0[credit] to trash any card you are accessing (even if it has no trash cost).\n<errata>Errata from CR 1.2</errata>",
         "title": "Demolition Run",
         "type_code": "event",
         "uniqueness": false
@@ -65,7 +65,7 @@
         "position": 4,
         "quantity": 1,
         "side_code": "runner",
-        "text": "As an additional cost to play this event, spend [click].\nMake a run on a remote server. If successful, instead of accessing cards, trash all cards in the server at no cost (even if they cannot normally be trashed).",
+        "text": "Run a remote server. If successful, instead of accessing cards, trash all cards installed in that server.\n<errata>Errata from CR 1.2</errata>",
         "title": "Singularity",
         "type_code": "event",
         "uniqueness": false
@@ -193,7 +193,7 @@
         "position": 11,
         "quantity": 1,
         "side_code": "runner",
-        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you access at no cost (even if it cannot normally be trashed).",
+        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you are accessing <i>(even if it has no trash cost)</i>.\n<errata>Errata from CR 1.2</errata>",
         "title": "Imp",
         "type_code": "program",
         "uniqueness": false

--- a/pack/cotc.json
+++ b/pack/cotc.json
@@ -192,7 +192,7 @@
         "quantity": 3,
         "side_code": "corp",
         "strength": 5,
-        "text": "Whenever an encounter with Anansi ends, do 3 net damage unless the Runner broke all subroutines on it.\n[subroutine] Look at the top 5 cards of R&D and arrange them in any order.\n[subroutine] You may draw 1 card. The Runner may pay 2[credit] to draw 1 card.\n[subroutine] Do 1 net damage.",
+        "text": "Whenever an encounter with Anansi ends, if the Runner did not break all subroutines on it, do 3 net damage.\n[subroutine] Look at the top 5 cards of R&D and arrange them in any order.\n[subroutine] You may draw 1 card. The Runner may pay 2[credit] to draw 1 card.\n[subroutine] Do 1 net damage.\n<errata>Errata from CR 1.2</errata>",
         "title": "Anansi",
         "type_code": "ice",
         "uniqueness": false

--- a/pack/dad.json
+++ b/pack/dad.json
@@ -769,7 +769,7 @@
         "position": 43,
         "quantity": 3,
         "side_code": "runner",
-        "text": "The first time each turn you access a card with a trash cost, you must trash it by paying its trash cost, if able.\nWhenever you access cards from HQ, access 1 additional card.",
+        "text": "The first time each turn you access a card with a trash cost, reveal it. You must trash that card by paying its trash cost, if able.\nWhenever you access cards from HQ, access 1 additional card.\n<errata>Errata from CR 1.2</errata>",
         "title": "Neutralize All Threats",
         "type_code": "resource",
         "uniqueness": true

--- a/pack/df.json
+++ b/pack/df.json
@@ -535,7 +535,7 @@
         "position": 30,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <em>(You are no longer accessing it.)</em>",
+        "text": "Whenever you make a successful run, you may trash this resource to name an agenda. The next time this run you access a copy of the named agenda, steal it, ignoring all costs. <i>(You are no longer accessing it.)</i>",
         "title": "Whistleblower",
         "type_code": "resource",
         "uniqueness": true
@@ -770,7 +770,7 @@
         "position": 43,
         "quantity": 3,
         "side_code": "corp",
-        "text": "The first time each turn you trash <em>(from any location)</em> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
+        "text": "The first time each turn you trash <i>(from any location)</i> a card that matches the faction of the Runner's identity, place 1 power counter on this asset.\n[click]<strong>, hosted power counter:</strong> Do 1 net damage.",
         "title": "Storgotic Resonator",
         "trash_cost": 2,
         "type_code": "asset",
@@ -1098,7 +1098,7 @@
         "position": 61,
         "quantity": 3,
         "side_code": "corp",
-        "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <em>(Shuffle R&D after searching it.)</em> Install that ice protecting a central server, paying 3[credit] less.",
+        "text": "As an additional cost to play this operation, spend [click].\nSearch R&D for a piece of ice and reveal it. <i>(Shuffle R&D after searching it.)</i> Install that ice protecting a central server, paying 3[credit] less.",
         "title": "Secure and Protect",
         "type_code": "operation",
         "uniqueness": false

--- a/pack/dt.json
+++ b/pack/dt.json
@@ -11,7 +11,7 @@
         "position": 101,
         "quantity": 3,
         "side_code": "runner",
-        "text": "As an additional cost to play this event, spend [click].\nMake a run on a remote server. If successful, instead of accessing cards, trash all cards in the server at no cost (even if they cannot normally be trashed).",
+        "text": "Run a remote server. If successful, instead of accessing cards, trash all cards installed in that server.\n<errata>Errata from CR 1.2</errata>",
         "title": "Singularity",
         "type_code": "event",
         "uniqueness": false

--- a/pack/fc.json
+++ b/pack/fc.json
@@ -69,7 +69,7 @@
         "position": 44,
         "quantity": 3,
         "side_code": "corp",
-        "text": "The Runner cannot jack out while running on this server unless he or she trashes 1 installed program.\nLimit 1 <strong>region</strong> per server.",
+        "text": "As an additional cost to jack out during a run on this server, the Runner must trash 1 installed program.\nLimit 1 <strong>region</strong> per server.\n<errata>Errata from CR 1.2</errata>",
         "title": "Port Anson Grid",
         "trash_cost": 5,
         "type_code": "upgrade",

--- a/pack/ftm.json
+++ b/pack/ftm.json
@@ -66,7 +66,7 @@
         "position": 99,
         "quantity": 3,
         "side_code": "runner",
-        "text": "The Corp cannot win the game unless the Runner is flatlined.\nWhen your turn begins, place 1 power counter on The Black File. When there are 3 or more power counters on The Black File, remove it from the game.\nLimit 1 per deck.",
+        "text": "The Corp cannot win the game except if you are flatlined.\nWhen your turn begins, place 1 power counter on The Black File. When there are 3 or more power counters on The Black File, remove it from the game.\nLimit 1 per deck.\n<errata>Errata from CR 1.2</errata>",
         "title": "The Black File",
         "type_code": "resource",
         "uniqueness": true

--- a/pack/ml.json
+++ b/pack/ml.json
@@ -238,25 +238,6 @@
         "uniqueness": true
     },
     {
-        "code": "11095",
-        "cost": 7,
-        "deck_limit": 3,
-        "faction_code": "nbn",
-        "faction_cost": 3,
-        "flavor": "Truth like the sunlight shines above all. ",
-        "illustrator": "Kari Guenther",
-        "keywords": "Sentry - Tracer",
-        "pack_code": "ml",
-        "position": 95,
-        "quantity": 3,
-        "side_code": "corp",
-        "strength": 6,
-        "text": "When the Runner encounters Thoth, give him or her 1 tag.\n[subroutine] <trace>Trace 4</trace> If successful, do 1 net damage for each tag the Runner has.\n[subroutine] <trace>Trace 4</trace> If successful, the Runner loses 1[credit] for each tag he or she has.",
-        "title": "Thoth",
-        "type_code": "ice",
-        "uniqueness": true
-    },
-    {
         "code": "11094",
         "cost": 2,
         "deck_limit": 3,
@@ -274,6 +255,25 @@
         "title": "IP Block",
         "type_code": "ice",
         "uniqueness": false
+    },
+    {
+        "code": "11095",
+        "cost": 7,
+        "deck_limit": 3,
+        "faction_code": "nbn",
+        "faction_cost": 3,
+        "flavor": "Truth like the sunlight shines above all. ",
+        "illustrator": "Kari Guenther",
+        "keywords": "Sentry - Tracer",
+        "pack_code": "ml",
+        "position": 95,
+        "quantity": 3,
+        "side_code": "corp",
+        "strength": 6,
+        "text": "When the Runner encounters Thoth, give him or her 1 tag.\n[subroutine] <trace>Trace 4</trace> If successful, do 1 net damage for each tag the Runner has.\n[subroutine] <trace>Trace 4</trace> If successful, the Runner loses 1[credit] for each tag he or she has.",
+        "title": "Thoth",
+        "type_code": "ice",
+        "uniqueness": true
     },
     {
         "code": "11096",

--- a/pack/mt.json
+++ b/pack/mt.json
@@ -248,7 +248,7 @@
         "position": 54,
         "quantity": 3,
         "side_code": "corp",
-        "text": "The first time the Runner spends at least 1[click] on his or her turn, gain 2[credit] unless the Runner just initiated a run on this server.",
+        "text": "The first time the Runner spends 1 or more [click] during their turn, gain 2[credit]. If those [click] were spent to take an action, the first time during that action a run on this server begins, pay 2[credit].\n<errata>Errata from CR 1.2</errata>",
         "title": "Sundew",
         "trash_cost": 2,
         "type_code": "asset",

--- a/pack/oh.json
+++ b/pack/oh.json
@@ -295,7 +295,7 @@
         "position": 97,
         "quantity": 3,
         "side_code": "corp",
-        "text": "Agendas accessed from this server cannot be stolen unless the Runner already has a copy of that agenda in his or her score area. This applies even during the run on which the Runner trashes Old Hollywood Grid.\nLimit 1 <strong>region</strong> per server.",
+        "text": "The Runner cannot steal agendas accessed from this server, even during the run on which they trash Old Hollywood Grid. Ignore this ability for any agenda the Runner has a copy of in their score area.\nLimit 1 <strong>region</strong> per server.\n<errata>Errata from CR 1.2</errata>",
         "title": "Old Hollywood Grid",
         "trash_cost": 4,
         "type_code": "upgrade",

--- a/pack/sc19.json
+++ b/pack/sc19.json
@@ -230,7 +230,7 @@
         "position": 13,
         "quantity": 2,
         "side_code": "runner",
-        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you access at no cost (even if it cannot normally be trashed).",
+        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you are accessing <i>(even if it has no trash cost)</i>.\n<errata>Errata from CR 1.2</errata>",
         "title": "Imp",
         "type_code": "program",
         "uniqueness": false
@@ -1656,7 +1656,7 @@
         "position": 92,
         "quantity": 1,
         "side_code": "corp",
-        "text": "The first time the Runner spends at least 1[click] on his or her turn, gain 2[credit] unless the Runner just initiated a run on this server.",
+        "text": "The first time the Runner spends 1 or more [click] during their turn, gain 2[credit]. If those [click] were spent to take an action, the first time during that action a run on this server begins, pay 2[credit].\n<errata>Errata from CR 1.2</errata>",
         "title": "Sundew",
         "trash_cost": 2,
         "type_code": "asset",

--- a/pack/ss.json
+++ b/pack/ss.json
@@ -11,7 +11,7 @@
         "position": 1,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Play only as your first [click].\nUntil the turn ends, whenever you access a card not in Archives, trash it at no cost (even if it cannot normally be trashed) and suffer 1 meat damage.",
+        "text": "Play only as your first [click].\nFor the remainder of the turn, whenever you access a card not in Archives, trash it and suffer 1 meat damage.\n<errata>Errata from CR 1.2</errata>",
         "title": "By Any Means",
         "type_code": "event",
         "uniqueness": false

--- a/pack/tc.json
+++ b/pack/tc.json
@@ -12,7 +12,7 @@
         "position": 61,
         "quantity": 3,
         "side_code": "runner",
-        "text": "[click]: Make a run on R&D. If successful, instead of accessing cards, look at the top 3 cards of R&D. Trash 1 of those cards at no cost (even if it cannot normally be trashed) and the Corp shuffles R&D.",
+        "text": "[click]: Run R&D. If successful, instead of accessing cards, look at the top 3 cards of R&D. Trash 1 of those cards, then the Corp shuffles R&D.\n<errata>Errata from CR 1.2</errata>",
         "title": "Keyhole",
         "type_code": "program",
         "uniqueness": false

--- a/pack/td.json
+++ b/pack/td.json
@@ -685,7 +685,7 @@
         "position": 38,
         "quantity": 3,
         "side_code": "corp",
-        "text": "As an additional cost to play this operation, spend [click][click].\nGain 10[credit] and draw 4 cards. Install 1 card (paying all costs).",
+        "text": "As an additional cost to play this operation, spend [click][click].\nGain 10[credit] and draw 4 cards. You may install 1 card.\n<errata>Errata from CR 1.2</errata>",
         "title": "Ultraviolet Clearance",
         "type_code": "operation",
         "uniqueness": false

--- a/pack/uao.json
+++ b/pack/uao.json
@@ -122,7 +122,7 @@
         "quantity": 3,
         "side_code": "corp",
         "strength": 2,
-        "text": "[subroutine] The Runner loses 1[credit] unless the Runner is tagged. If the Runner is tagged, he or she loses all credits in his or her credit pool and the Corp trashes Universal Connectivity Fee.",
+        "text": "[subroutine] If the Runner is not tagged, they lose 1[credit]. If the Runner is tagged, they lose all credits in his or her credit pool and the Corp trashes Universal Connectivity Fee.\n<errata>Errata from CR 1.2</errata>",
         "title": "Universal Connectivity Fee",
         "type_code": "ice",
         "uniqueness": false

--- a/pack/win.json
+++ b/pack/win.json
@@ -12,7 +12,7 @@
         "position": 81,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Once per turn, you may remove X virus counters from your installed cards to trash a card that you access at no cost (even if it cannot normally be trashed). X is that card's rez or play cost.",
+        "text": "Once per turn, you may remove any X virus counters from your installed cards to trash a non-agenda card you are accessing <i>(even if it has no trash cost)</i>.\n<errata>Errata from CR 1.2</errata>",
         "title": "Freedom Khumalo: Crypto-Anarchist",
         "type_code": "identity",
         "uniqueness": false

--- a/pack/wla.json
+++ b/pack/wla.json
@@ -49,7 +49,7 @@
         "position": 3,
         "quantity": 3,
         "side_code": "runner",
-        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you access at no cost (even if it cannot normally be trashed).",
+        "text": "Place 2 virus counters on Imp when it is installed.\nOnce per turn, you may remove 1 hosted virus counter to trash a card you are accessing <i>(even if it has no trash cost)</i>.\n<errata>Errata from CR 1.2</errata>",
         "title": "Imp",
         "type_code": "program",
         "uniqueness": false


### PR DESCRIPTION
Includes all new errata issued in the Comprehensive Rules 1.2 update, along with moving Thoth to it's correct place in the json (no function change) and changing the `<em>` tag to an `<i>` tag on the recommendation of a number of people.