### PR TITLE
Correct Masvingo flavor text

### DIFF
--- a/pack/win.json
+++ b/pack/win.json
@@ -326,7 +326,7 @@
         "deck_limit": 3,
         "faction_code": "weyland-consortium",
         "faction_cost": 2,
-        "flavor": "No matter which direcion ze climbed, the blocks reshuffled, zipping in from left to right, bottom to top. It was going to be a long hike.",
+        "flavor": "No matter which direction ze climbed, the blocks reshuffled, zipping in from left to right, bottom to top. It was going to be a long hike.",
         "illustrator": "Pavel Kolomeyets",
         "keywords": "Barrier",
         "pack_code": "win",


### PR DESCRIPTION
Adds missing T to "direction"