### PR TITLE
Fix Hadrian's Wall flavor text capitalization

### DIFF
--- a/pack/core2.json
+++ b/pack/core2.json
@@ -1546,7 +1546,7 @@
         "deck_limit": 3,
         "faction_code": "weyland-consortium",
         "faction_cost": 3,
-        "flavor": "\"He had a bit of an ego, ol' Hadrian. his constructs live up to it though.\" -g00ru",
+        "flavor": "\"He had a bit of an ego, ol' Hadrian. His constructs live up to it though.\" -g00ru",
         "illustrator": "Liiga Smilshkalne",
         "keywords": "Barrier",
         "pack_code": "core2",


### PR DESCRIPTION
Fixed this in Original Core, but the issue was present in the Revised Core and System Core 2019 data too. This fixes Revised Core.