### PR TITLE
Add missing versions

### DIFF
--- a/mwl.json
+++ b/mwl.json
@@ -33,6 +33,9 @@
             },
             "06099": {
                 "global_penalty": 1
+            },
+            "25073": {
+                "global_penalty": 1
             }
         },
         "code": "NAPD_MWL_1.0",
@@ -84,6 +87,9 @@
                 "global_penalty": 1
             },
             "10018": {
+                "global_penalty": 1
+            },
+            "25073": {
                 "global_penalty": 1
             }
         },
@@ -160,6 +166,12 @@
     },
     {
         "cards": {
+            "01044": {
+                "is_restricted": 1
+            },
+            "01047": {
+                "is_restricted": 1
+            },
             "03035": {
                 "is_restricted": 1
             },
@@ -240,6 +252,9 @@
             },
             "20052": {
                 "is_restricted": 1
+            },
+            "25056": {
+                "is_restricted": 1
             }
         },
         "code": "NAPD_MWL_2.0",
@@ -248,6 +263,12 @@
     },
     {
         "cards": {
+            "01044": {
+                "is_restricted": 1
+            },
+            "01047": {
+                "is_restricted": 1
+            },
             "03035": {
                 "is_restricted": 1
             },
@@ -342,6 +363,9 @@
                 "is_restricted": 1
             },
             "20052": {
+                "is_restricted": 1
+            },
+            "25056": {
                 "is_restricted": 1
             }
         },
@@ -476,6 +500,9 @@
             },
             "21118": {
                 "is_restricted": 1
+            },
+            "25056": {
+                "is_restricted": 1
             }
         },
         "code": "NAPD_MWL_2.2",
@@ -484,6 +511,9 @@
     },
     {
         "cards": {
+            "01047": {
+                "is_restricted": 1
+            },
             "03001": {
                 "deck_limit": 0
             },
@@ -589,6 +619,9 @@
             "12103": {
                 "deck_limit": 0
             },
+            "20052": {
+                "is_restricted": 1
+            },
             "21101": {
                 "deck_limit": 0
             },
@@ -614,6 +647,9 @@
     },
     {
         "cards": {
+            "01047": {
+                "is_restricted": 1
+            },
             "03001": {
                 "deck_limit": 0
             },
@@ -722,6 +758,9 @@
             "12103": {
                 "deck_limit": 0
             },
+            "20052": {
+                "is_restricted": 1
+            },
             "21101": {
                 "deck_limit": 0
             },
@@ -750,6 +789,9 @@
     },
     {
         "cards": {
+            "01047": {
+                "is_restricted": 1
+            },
             "03001": {
                 "deck_limit": 0
             },


### PR DESCRIPTION
Each of the included entries is a different printing/version than the one at release, which is why it's not included. The cards are Eli 1.0, Aesop's Pawnshop, and Magnum Opus.