### PR TITLE
Added Interns errata from 2nd FFG printing

### DIFF
--- a/pack/mt.json
+++ b/pack/mt.json
@@ -358,7 +358,7 @@
         "position": 60,
         "quantity": 3,
         "side_code": "corp",
-        "text": "As an additional cost to play this operation, spend [click].\nInstall a card from Archives or HQ, ignoring the install cost.",
+        "text": "As an additional cost to play this operation, spend [click].\nInstall a non-operation card from Archives or HQ, ignoring the install cost.",
         "title": "Interns",
         "type_code": "operation",
         "uniqueness": false


### PR DESCRIPTION
I already SCPed an updated card image onto production, so this just makes the text match the image now.