### PR TITLE
Fixed issue where card ability had been entirely overwritten

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -1279,7 +1279,7 @@
         "position": 71,
         "quantity": 1,
         "side_code": "corp",
-        "text": "[interrupt] - When a card would be exposed, you may rez this asset.\n<errata>Errata from CR 1.4</errata>",
+        "text": "[interrupt] - When a card would be exposed, you may rez this asset.\n1[credit] or [trash]: Prevent 1 card from being exposed.\n<errata>Errata from CR 1.4</errata>",
         "title": "Zaibatsu Loyalty",
         "trash_cost": 4,
         "type_code": "asset",


### PR DESCRIPTION
@NoahTheDuke took the errata too literally:

```
11.2.6. Zaibatsu Loyalty (Original Core 71)
a. Should read: “[interrupt]– When a card would be exposed, you may rez this asset.”
```
😛 😝 