### PR TITLE
Minor copy-editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ The `text` and `flavor` properties of a card may use custom tags. These are:
 * Cards designed by World Champions use the `<champion>` tag (usually as the `flavor`), e.g. `<champion>Designed by 2012 World Champion Jeremy Zwirn</champion>` for Architect.
 * Traces use the `<trace>` tag. For example, `<trace>Trace 2</trace> Do 1 net damage.` results in the following:
  
-  > **Trace<sup>2</sup>**– Do 1 net damage. 
+  > **Trace \[2\]**– Do 1 net damage. 
 

--- a/pack/oac.json
+++ b/pack/oac.json
@@ -924,7 +924,7 @@
         "deck_limit": 3,
         "faction_code": "anarch",
         "faction_cost": 2,
-        "flavor": "Scraps of code drifting around the network can congeal into pools of data. Within this primordial soup the code breaks, re-assemble, mutates. Evolves.",
+        "flavor": "Scraps of code drifting around the network can congeal into pools of data. Within this primordial soup the code breaks, re-assembles, mutates. Evolves.",
         "illustrator": "Eren Arik",
         "keywords": "Virtual",
         "pack_code": "oac",

--- a/pack/ur.json
+++ b/pack/ur.json
@@ -468,7 +468,7 @@
         "position": 91,
         "quantity": 3,
         "side_code": "runner",
-        "text": "+1[link]\nWhenever you install a non-<strong>AI</strong> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength until the end of the turn.",
+        "text": "+1[link]\nWhenever you install a non-<strong>AI</strong> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength for the remainder of the turn.",
         "title": "Cybertrooper Talut",
         "type_code": "resource",
         "uniqueness": true

--- a/pack/urbp.json
+++ b/pack/urbp.json
@@ -48,7 +48,7 @@
         "position": 3,
         "quantity": 3,
         "side_code": "runner",
-        "text": "+1[link]\nWhenever you install a non-<strong>AI</strongnisei.net/> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength for the remainder of the turn.",
+        "text": "+1[link]\nWhenever you install a non-<strong>AI</strong> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength for the remainder of the turn.",
         "title": "Cybertrooper Talut",
         "type_code": "resource",
         "uniqueness": true

--- a/pack/urbp.json
+++ b/pack/urbp.json
@@ -48,7 +48,7 @@
         "position": 3,
         "quantity": 3,
         "side_code": "runner",
-        "text": "+1[link]\nWhenever you install a non-<strong>AI</strong> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength until the end of the turn.",
+        "text": "+1[link]\nWhenever you install a non-<strong>AI</strongnisei.net/> <strong>icebreaker</strong>, that <strong>icebreaker</strong> has +2 strength for the remainder of the turn.",
         "title": "Cybertrooper Talut",
         "type_code": "resource",
         "uniqueness": true


### PR DESCRIPTION
Turns out, the database text for Cybertrooper Talut has been subtly wrong ("until the end of the turn" vs. "for the remainder of the turn") this whole time! Fixed in Uprising and Uprising Booster Pack.

Also fixed the flavor text of Virus Breeding Ground and changed the readme so that it shows the modern NISEI style for traces (with square brackets instead of superscript).